### PR TITLE
Support dynamic tool registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Environment variable options:
 * `WORKING_DIRECTORY`: **Required.** Determines where Prism CLI commands are run from.
 * `PRISMATIC_URL`: Optional. `https://app.prismatic.io` by default.
 * `PRISM_PATH`: Optional. For pointing to a specific installation of `prism`.
-* `TOOLSET`: Optional. Specify the development toolset you'd like to use -- `integration`, `component`, or by default all tools. Being selective about what tools to register may improve performance.
+* `TOOLSETS`: Optional. Specify the development toolsets you'd like to use -- `integration`, `component`, or by default all tools. Being selective about what tools to register may improve performance.
 
 ### With Claude Desktop or Claude Code
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -555,30 +555,42 @@ function registerComponentTools() {
   );
 }
 
-function registerTools(toolset?: string) {
-  if (toolset && !VALID_TOOLSETS.includes(toolset)) {
-    throw Error(
-      `Invalid toolset: ${toolset}. Valid categories are: ${VALID_TOOLSETS.join(", ")}`
+function registerTools(toolsets: string[] = []) {
+  if (toolsets && toolsets.length > 0) {
+    const invalidToolsets = toolsets.filter(
+      (toolset) => !VALID_TOOLSETS.includes(toolset)
     );
+    if (invalidToolsets.length > 0) {
+      throw Error(`Invalid toolset: ${invalidToolsets.join(", ")}. Valid categories are: ${VALID_TOOLSETS.join(", ")}`);
+    }
   }
 
   registerGeneralTools();
 
-  switch (toolset) {
-    case "component":
-      registerComponentTools();
-      break;
-    case "integration":
-      registerIntegrationTools();
-      break;
-    default:
-      registerComponentTools();
-      registerIntegrationTools();
-      break;
+  if (toolsets.length > 0) {
+    toolsets.forEach((toolset) => {
+      switch (toolset) {
+        case "component":
+          registerComponentTools();
+          break;
+        case "integration":
+          registerIntegrationTools();
+          break;
+        default:
+          break;
+      }
+    });
+  } else {
+    registerComponentTools();
+    registerIntegrationTools();
   }
 }
 
-registerTools(process.env.TOOLSET);
+const toolsetsEnv = process.env.TOOLSETS;
+const toolsets = toolsetsEnv
+  ? toolsetsEnv.split(/[,\s]+/).filter((ts) => ts.trim().length > 0)
+  : [];
+registerTools(toolsets);
 
 async function main() {
   try {


### PR DESCRIPTION
This PR is branched off of https://github.com/prismatic-io/prism-mcp/pull/4.

SE reported that AI agents may sometimes degrade if provided too many tools. This PR makes it so that users can be specific about what set of prism-mcp tools they'd like to use -- for now the only options are `integration` dev tools, `component` dev tools, and then by default all tools are registered.

There are a few tools that are commonly available across categories.