### PR TITLE
Update tools to use in-src component manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ This MCP server provides several tools, organized into categories. You may regis
 
 #### Codegen
 
-- **prism_install_component_manifest**: Generate line to add to a CNI's devDependencies that installs a Prismatic component manifest
+- **prism_install_component_manifest**: Generate component manifest in CNI src directory (requires spectral@10.6.0 or greater)
+- **prism_install_legacy_component_manifest**: Generate line to add to a CNI's devDependencies for legacy component manifest installation
 - **prism_integrations_generate_flow**: Generate boilerplate file for a CNI flow
 - **prism_integrations_generate_config_page**: Generate boilerplate code for a CNI config page
 - **prism_integrations_generate_config_var**: Generate boilerplate code for a config variable
-- **prism_integrations_generate_connection_config_var**: Generate boilerplate code for a connection config variable
-- **prism_integrations_generate_datasource_config_var**: Generate boilerplate code for a datasource config variable
+- **prism_integrations_add_connection_config_var**: Returns path to connection wrapper function if available, otherwise generates boilerplate code for a connection config variable
+- **prism_integrations_add_datasource_config_var**: Returns path to datasource wrapper function if available, otherwise generates boilerplate code for a datasource config variable
 
 ### Component Tools (Toolset: "component")
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,4 +1,5 @@
 import { camelCase, kebabCase } from "lodash-es";
+import { existsSync } from "node:fs";
 
 export function generateFlowFile(name: string, description?: string): string {
   return `
@@ -43,17 +44,25 @@ export function generateConfigVar(name: string, dataType: string, description?: 
 
 export function generateConnectionConfigVar(
   name: string,
-  componentRef?: { component: string; key: string },
+  componentRef?: { componentKey: string; connectionKey: string },
+  directory?: string,
 ): string {
-  const isComponentRef = componentRef?.component;
+  const isComponentRef = componentRef?.componentKey;
   if (isComponentRef) {
+    const connectionPath = `${directory}/src/manifests/${componentRef.componentKey}/connections/`;
+    const manifestInSrc = existsSync(connectionPath);
+
+    if (manifestInSrc) {
+      return connectionPath;
+    }
+
     return `
 "${name}": connectionConfigVar({
   stableKey: "${kebabCase(name)}",
   dataType: "connection",
   connection: {
-    component: "${componentRef.component}",
-    key: "${componentRef.key}",
+    component: "${componentRef.componentKey}",
+    key: "${componentRef.connectionKey}",
     values: {
       // Fill according to type hinting.
     },
@@ -76,20 +85,28 @@ export function generateConnectionConfigVar(
 export function generateDataSourceConfigVar(
   name: string,
   dataType: string,
-  componentRef?: { component: string; key: string },
+  componentRef?: { componentKey: string; dataSourceKey: string },
+  directory?: string,
 ): string {
-  const isComponentRef = componentRef?.component;
+  const isComponentRef = componentRef?.componentKey;
   if (isComponentRef) {
+    const dataSourcePath = `${directory}/src/manifests/${componentRef.componentKey}/dataSources/`;
+    const manifestInSrc = existsSync(dataSourcePath);
+
+    if (manifestInSrc) {
+      return dataSourcePath;
+    }
+
     return `
 "${name}": dataSourceConfigVar({
   stableKey: "${kebabCase(name)}",
   dataType: "${dataType}",
   dataSource: {
-    component: "${componentRef.component}",
-    key: "${componentRef.key}",
+    component: "${componentRef.componentKey}",
+    key: "${componentRef.dataSourceKey}",
     values: {
       // Populate values according to the provided component types.
-      // You may need to ensure that the ${componentRef.component} component-manifest is installed.
+      // You may need to ensure that the ${componentRef.componentKey} component-manifest is installed.
     },
   },
 }),

--- a/src/prism-cli-manager.ts
+++ b/src/prism-cli-manager.ts
@@ -1,13 +1,13 @@
 import { exec } from "node:child_process";
-import { promisify } from "node:util";
-import { existsSync } from "fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { existsSync } from "fs";
+
+export const execAsync = promisify(exec);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-export const execAsync = promisify(exec);
 
 export const DEFAULT_PRISMATIC_URL = "https://app.prismatic.io/";
 
@@ -83,7 +83,7 @@ export class PrismCLIManager {
 
     if (isInstalled !== true) {
       throw new Error(
-        `Prismatic CLI is not properly installed. Please ensure @prismatic-io/prism is installed in your project dependencies.`,
+        "Prismatic CLI is not properly installed. Please ensure @prismatic-io/prism is installed in your project dependencies.",
       );
     }
 


### PR DESCRIPTION
This PR adds tools that take advantage of the in-src component manifest changes proposed in https://github.com/prismatic-io/spectral/pull/349.

To use these tools, your integration will need to be on `spectral@next` (`10.6.0-alpha.0` at the time of writing). The changes are written in a way where if you are on an older version of spectral, things should still work as they did before (including whatever weirdness that comes with that).

**NOTE:** AI agents will generally do better if all of your component-manifests are installed in src/ as opposed to having some in src/ and some using packages. If you are in a mid-migration state, agents may require some human prompting to let them know that the manifests are spread out in different places.