### PR TITLE
prism-mcp - 1.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,8 @@ Example setup:
     "prism": {
       "type": "stdio",
       "command": "npx @prismatic-io/prism-mcp",
-      "args": ["/path/to/prism-mcp/dist/index.js"],
-      "env": {
-        "WORKING_DIRECTORY": "/path/to/the/work/dir/"
-      }
+      "args": ["-y", "/path/to/the/work/dir/"],
+      "env": {}
     }
   }
 }
@@ -93,12 +91,15 @@ Example setup:
 
 Replace the path args as needed.
 
-Environment variable options:
+Command-line arguments:
 
-- `WORKING_DIRECTORY`: **Required.** Determines where Prism CLI commands are run from.
-- `PRISMATIC_URL`: Optional. `https://app.prismatic.io` by default.
-- `PRISM_PATH`: Optional. For pointing to a specific installation of `prism`.
-- `TOOLSETS`: Optional. Specify the development toolsets you'd like to use -- `integration`, `component`, or by default all tools. Being selective about what tools to register may improve performance.
+- First argument: **Required.** Working directory path that determines where Prism CLI commands are run from.
+- Remaining arguments: **Optional.** Toolsets to enable (`integration`, `component`). If no toolsets are specified, all tools are registered by default. Being selective about toolsets may improve performance.
+
+Optional environment variable options:
+
+- `PRISMATIC_URL`: `https://app.prismatic.io` by default.
+- `PRISM_PATH`: For pointing to a specific installation of `prism`.
 
 ### With Claude Desktop or Claude Code
 

--- a/README.md
+++ b/README.md
@@ -68,26 +68,6 @@ If no `TOOLSETS` environment variable is set, all tools are registered by defaul
    prism login
    ```
 
-## Installation
-
-1. Clone this repository:
-
-   ```bash
-   git clone <repository-url>
-   cd prism-mcp
-   ```
-
-2. Install dependencies:
-
-   ```bash
-   npm install
-   ```
-
-3. Build the project:
-   ```bash
-   npm run build
-   ```
-
 ## Usage
 
 ### Config
@@ -101,7 +81,7 @@ Example setup:
   "mcpServers": {
     "prism": {
       "type": "stdio",
-      "command": "node",
+      "command": "npx @prismatic-io/prism-mcp",
       "args": ["/path/to/prism-mcp/dist/index.js"],
       "env": {
         "WORKING_DIRECTORY": "/path/to/the/work/dir/"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@prismatic-io/prism-mcp",
   "version": "1.0.0",
   "description": "MCP server that wraps Prismatic's Prism CLI tool",
-  "keywords": ["prismatic"],
+  "keywords": [
+    "prismatic"
+  ],
   "main": "dist/index.js",
   "type": "module",
   "homepage": "https://prismatic.io",
@@ -11,17 +13,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prismatic-io/prism-mcp.git"
+    "url": "git+https://github.com/prismatic-io/prism-mcp.git"
   },
   "publishConfig": {
     "access": "public",
     "tag": "next",
     "registry": "https://registry.npmjs.org"
   },
-  "files": ["dist/"],
+  "files": [
+    "dist/"
+  ],
   "license": "MIT",
   "bin": {
-    "prism-mcp": "./dist/index.js"
+    "prism-mcp": "dist/index.js"
   },
   "scripts": {
     "build": "tsc && chmod 755 dist/index.js",
@@ -43,5 +47,6 @@
     "@biomejs/biome": "^1.6.3",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.15.30"
-  }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -32,7 +32,11 @@ ${name}: configPage({
 `;
 }
 
-export function generateConfigVar(name: string, dataType: string, description?: string): string {
+export function generateConfigVar(
+  name: string,
+  dataType: string,
+  description?: string
+): string {
   return `
 "${name}": configVar({
   stableKey: "${kebabCase(name)}",
@@ -46,6 +50,7 @@ export function generateConnectionConfigVar(
   name: string,
   componentRef?: { componentKey: string; connectionKey: string },
   directory?: string,
+  forceLegacy?: boolean
 ): string {
   const isComponentRef = componentRef?.componentKey;
   if (isComponentRef) {
@@ -54,6 +59,10 @@ export function generateConnectionConfigVar(
 
     if (manifestInSrc) {
       return connectionPath;
+    } else if (!forceLegacy) {
+      throw new Error(
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
+      );
     }
 
     return `
@@ -87,6 +96,7 @@ export function generateDataSourceConfigVar(
   dataType: string,
   componentRef?: { componentKey: string; dataSourceKey: string },
   directory?: string,
+  forceLegacy?: boolean,
 ): string {
   const isComponentRef = componentRef?.componentKey;
   if (isComponentRef) {
@@ -95,6 +105,10 @@ export function generateDataSourceConfigVar(
 
     if (manifestInSrc) {
       return dataSourcePath;
+    } else if (!forceLegacy) {
+      throw new Error(
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
+      );
     }
 
     return `
@@ -106,7 +120,9 @@ export function generateDataSourceConfigVar(
     key: "${componentRef.dataSourceKey}",
     values: {
       // Populate values according to the provided component types.
-      // You may need to ensure that the ${componentRef.componentKey} component-manifest is installed.
+      // You may need to ensure that the ${
+        componentRef.componentKey
+      } component-manifest is installed.
     },
   },
 }),

--- a/src/prism-cli-manager.ts
+++ b/src/prism-cli-manager.ts
@@ -44,15 +44,12 @@ export class PrismCLIManager {
     }
 
     // For new instance creation, require working directory
-    const workDir = workingDirectory || process.env.WORKING_DIRECTORY;
-    const url = prismaticUrl || process.env.PRISMATIC_URL;
-    if (!workDir) {
-      throw new Error(
-        `WORKING_DIRECTORY must be provided or set as environment variable. Provided: ${workDir}`,
-      );
+    if (!workingDirectory) {
+      throw new Error("A working directory must be provided.");
     }
-
-    PrismCLIManager.instance = new PrismCLIManager(workDir, url);
+    
+    const url = prismaticUrl || process.env.PRISMATIC_URL;
+    PrismCLIManager.instance = new PrismCLIManager(workingDirectory, url);
     return PrismCLIManager.instance;
   }
 

--- a/src/prism-cli-manager.ts
+++ b/src/prism-cli-manager.ts
@@ -36,7 +36,14 @@ export class PrismCLIManager {
    * @returns {PrismCLIManager} The singleton instance of PrismCLIManager
    */
   public static getInstance(workingDirectory?: string, prismaticUrl?: string): PrismCLIManager {
-    // Use provided working directory or fall back to environment variable
+    if (PrismCLIManager.instance) {
+      if (prismaticUrl) {
+        PrismCLIManager.instance.prismaticUrl = prismaticUrl;
+      }
+      return PrismCLIManager.instance;
+    }
+
+    // For new instance creation, require working directory
     const workDir = workingDirectory || process.env.WORKING_DIRECTORY;
     const url = prismaticUrl || process.env.PRISMATIC_URL;
     if (!workDir) {
@@ -45,13 +52,7 @@ export class PrismCLIManager {
       );
     }
 
-    if (!PrismCLIManager.instance) {
-      PrismCLIManager.instance = new PrismCLIManager(workDir, url);
-    } else if (prismaticUrl) {
-      // Update the URL if a new one is provided
-      PrismCLIManager.instance.prismaticUrl = prismaticUrl;
-    }
-
+    PrismCLIManager.instance = new PrismCLIManager(workDir, url);
     return PrismCLIManager.instance;
   }
 
@@ -150,6 +151,14 @@ export class PrismCLIManager {
     const { stdout } = await this.executeCommand("--version");
 
     return stdout.trim();
+  }
+
+  /**
+   * Gets the working directory.
+   * @returns {string} The working directory
+   */
+  public getWorkingDirectory(): string {
+    return this.workingDirectory;
   }
 
   /**


### PR DESCRIPTION
This PR:

* Updates the README with new instructions
* Makes some improvements to the config var addition flow (i.e. we will warn the agent if it attempts to add a config var without attempting to install a manifest first)
* Swaps WORKING_DIRECTORY and TOOLSETS to arguments instead of environment variables.

Once this is approved and merged we can publish 1.0.