### PR TITLE
Post-publish fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,12 @@ Example setup:
   "mcpServers": {
     "prism": {
       "type": "stdio",
-      "command": "npx @prismatic-io/prism-mcp",
-      "args": ["-y", "/path/to/the/work/dir/"],
+      "command": "npx",
+      "args": [
+        "-y",
+        "@prismatic-io/prism-mcp",
+        "/path/to/the/work/dir/"
+      ],
       "env": {}
     }
   }
@@ -99,7 +103,6 @@ Command-line arguments:
 Optional environment variable options:
 
 - `PRISMATIC_URL`: `https://app.prismatic.io` by default.
-- `PRISM_PATH`: For pointing to a specific installation of `prism`.
 
 ### With Claude Desktop or Claude Code
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
 {
   "name": "@prismatic-io/prism-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server that wraps Prismatic's Prism CLI tool",
-  "keywords": [
-    "prismatic"
-  ],
+  "keywords": ["prismatic"],
   "main": "dist/index.js",
   "type": "module",
   "homepage": "https://prismatic.io",
@@ -20,9 +18,7 @@
     "tag": "next",
     "registry": "https://registry.npmjs.org"
   },
-  "files": [
-    "dist/"
-  ],
+  "files": ["dist/"],
   "license": "MIT",
   "bin": {
     "prism-mcp": "dist/index.js"

--- a/src/findExecutablePath.ts
+++ b/src/findExecutablePath.ts
@@ -1,9 +1,4 @@
-import { exec } from "node:child_process";
-import { existsSync } from "node:fs";
-import * as path from "node:path";
-import { promisify } from "node:util";
-
-const execAsync = promisify(exec);
+import { execAsync } from "./helpers.js";
 
 interface FindExecutablePathOptions {
   npxFallback?: string;
@@ -30,67 +25,7 @@ export async function findExecutablePath(
         return null;
       }
     },
-    // 2. Try npm config get prefix
-    async () => {
-      try {
-        const { stdout } = await execAsync("npm config get prefix");
-        const npmPrefix = stdout.trim();
-        const globalBin = path.join(npmPrefix, "bin", executable);
-
-        return existsSync(globalBin) ? globalBin : null;
-      } catch {
-        return null;
-      }
-    },
-    // 3. Try common macOS locations
-    () => {
-      const homebrewPath = `/opt/homebrew/bin/${executable}`;
-
-      return existsSync(homebrewPath) ? Promise.resolve(homebrewPath) : Promise.resolve(null);
-    },
-    // 4. Try user's global npm directory
-    () => {
-      const userLocalPath = path.join(process.env.HOME || "", ".npm-global", "bin", executable);
-
-      return existsSync(userLocalPath) ? Promise.resolve(userLocalPath) : Promise.resolve(null);
-    },
-    // 5. Try nvm installation
-    () => {
-      const nvmPath = path.join(
-        process.env.HOME || "",
-        ".nvm",
-        "versions",
-        "node",
-        "current",
-        "bin",
-        executable,
-      );
-
-      return existsSync(nvmPath) ? Promise.resolve(nvmPath) : Promise.resolve(null);
-    },
-    // 6. Try asdf shims
-    () => {
-      const asdfShim = path.join(process.env.HOME || "", ".asdf", "shims", executable);
-
-      return existsSync(asdfShim) ? Promise.resolve(asdfShim) : Promise.resolve(null);
-    },
-    // 7. Try asdf Node.js installation
-    async () => {
-      try {
-        const { stdout } = await execAsync("asdf where nodejs");
-        const nodejsPath = stdout.trim();
-
-        if (nodejsPath) {
-          const execPath = path.join(nodejsPath, "bin", executable);
-
-          return existsSync(execPath) ? execPath : null;
-        }
-        return null;
-      } catch {
-        return null;
-      }
-    },
-    // 8. Try npx fallback if provided
+    // 2. Use npx fallback
     ...(npxFallback
       ? [
           async () => {

--- a/src/findExecutablePath.ts
+++ b/src/findExecutablePath.ts
@@ -1,0 +1,123 @@
+import { exec } from "node:child_process";
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+interface FindExecutablePathOptions {
+  npxFallback?: string;
+  logPrefix?: string;
+}
+
+export async function findExecutablePath(
+  executable: string,
+  options: FindExecutablePathOptions = {},
+): Promise<string | null> {
+  const { npxFallback, logPrefix = "findExecutablePath" } = options;
+
+  // Try multiple approaches to find the executable
+  const approaches = [
+    // 1. Try which/where command
+    async () => {
+      try {
+        const cmd = process.platform === "win32" ? `where ${executable}` : `which ${executable}`;
+        const { stdout } = await execAsync(cmd);
+        const result = stdout.split(/\r?\n/)[0].trim();
+
+        return result || null;
+      } catch {
+        return null;
+      }
+    },
+    // 2. Try npm config get prefix
+    async () => {
+      try {
+        const { stdout } = await execAsync("npm config get prefix");
+        const npmPrefix = stdout.trim();
+        const globalBin = path.join(npmPrefix, "bin", executable);
+
+        return existsSync(globalBin) ? globalBin : null;
+      } catch {
+        return null;
+      }
+    },
+    // 3. Try common macOS locations
+    () => {
+      const homebrewPath = `/opt/homebrew/bin/${executable}`;
+
+      return existsSync(homebrewPath) ? Promise.resolve(homebrewPath) : Promise.resolve(null);
+    },
+    // 4. Try user's global npm directory
+    () => {
+      const userLocalPath = path.join(process.env.HOME || "", ".npm-global", "bin", executable);
+
+      return existsSync(userLocalPath) ? Promise.resolve(userLocalPath) : Promise.resolve(null);
+    },
+    // 5. Try nvm installation
+    () => {
+      const nvmPath = path.join(
+        process.env.HOME || "",
+        ".nvm",
+        "versions",
+        "node",
+        "current",
+        "bin",
+        executable,
+      );
+
+      return existsSync(nvmPath) ? Promise.resolve(nvmPath) : Promise.resolve(null);
+    },
+    // 6. Try asdf shims
+    () => {
+      const asdfShim = path.join(process.env.HOME || "", ".asdf", "shims", executable);
+
+      return existsSync(asdfShim) ? Promise.resolve(asdfShim) : Promise.resolve(null);
+    },
+    // 7. Try asdf Node.js installation
+    async () => {
+      try {
+        const { stdout } = await execAsync("asdf where nodejs");
+        const nodejsPath = stdout.trim();
+
+        if (nodejsPath) {
+          const execPath = path.join(nodejsPath, "bin", executable);
+
+          return existsSync(execPath) ? execPath : null;
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    },
+    // 8. Try npx fallback if provided
+    ...(npxFallback
+      ? [
+          async () => {
+            try {
+              await execAsync(`npx --yes ${npxFallback} --version`);
+
+              return `npx --yes ${npxFallback}`;
+            } catch {
+              return null;
+            }
+          },
+        ]
+      : []),
+  ];
+
+  for (const approach of approaches) {
+    try {
+      const result = await approach();
+
+      if (result) {
+        console.log(`${logPrefix}: Found ${executable} at:`, result);
+        return result;
+      }
+    } catch (error) {
+      console.error(`${logPrefix}: Error checking ${executable} path:`, error);
+    }
+  }
+
+  return null;
+}

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -32,11 +32,7 @@ ${name}: configPage({
 `;
 }
 
-export function generateConfigVar(
-  name: string,
-  dataType: string,
-  description?: string
-): string {
+export function generateConfigVar(name: string, dataType: string, description?: string): string {
   return `
 "${name}": configVar({
   stableKey: "${kebabCase(name)}",
@@ -50,7 +46,7 @@ export function generateConnectionConfigVar(
   name: string,
   componentRef?: { componentKey: string; connectionKey: string },
   directory?: string,
-  forceLegacy?: boolean
+  forceLegacy?: boolean,
 ): string {
   const isComponentRef = componentRef?.componentKey;
   if (isComponentRef) {
@@ -61,7 +57,7 @@ export function generateConnectionConfigVar(
       return connectionPath;
     } else if (!forceLegacy) {
       throw new Error(
-        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`,
       );
     }
 
@@ -107,7 +103,7 @@ export function generateDataSourceConfigVar(
       return dataSourcePath;
     } else if (!forceLegacy) {
       throw new Error(
-        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`,
       );
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,4 @@
+import { findExecutablePath } from "./findExecutablePath.js";
 import { PrismCLIManager } from "./prism-cli-manager.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -84,4 +85,14 @@ export function buildCommand(baseCommand: string, options: Record<string, any>):
   }
 
   return command;
+}
+
+/**
+ * Find prism executable path.
+ */
+export async function findPrismPath(): Promise<string | null> {
+  return findExecutablePath("prism", {
+    npxFallback: "@prismatic-io/prism",
+    logPrefix: "findPrismPath",
+  });
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,10 @@
+import { exec } from "node:child_process";
 import { findExecutablePath } from "./findExecutablePath.js";
 import { PrismCLIManager } from "./prism-cli-manager.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { promisify } from "node:util";
+
+export const execAsync = promisify(exec);
 
 /**
  * Parse output and format as CallToolResult

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import { snakeCase } from "lodash-es";
 import path from "node:path";
 import { z } from "zod";
 
-import { formatToolResult, lookupFlowUrl, buildCommand } from "./helpers.js";
-import { execAsync, PrismCLIManager } from "./prism-cli-manager.js";
+import { formatToolResult, lookupFlowUrl, buildCommand, execAsync } from "./helpers.js";
+import { PrismCLIManager } from "./prism-cli-manager.js";
 import {
   generateConfigPage,
   generateConfigVar,

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,6 @@ function registerIntegrationTools() {
       }
     },
   );
-
   server.tool(
     "prism_integrations_init",
     "Initialize a new Prismatic Code Native Integration (CNI)",
@@ -280,7 +279,13 @@ function registerIntegrationTools() {
           cwd: directory || manager.getWorkingDirectory(),
         });
 
-        return formatToolResult(result.stdout);
+        return formatToolResult(
+          JSON.stringify({
+            stdout: result.stdout,
+            instruction:
+              "The AI agent should update the componentRegistry file after installation.",
+          }),
+        );
       } catch (error) {
         throw new Error(`Failed to generate boilerplate: ${(error as Error).message}.`);
       }
@@ -296,10 +301,13 @@ function registerIntegrationTools() {
     },
     async ({ componentKey }) => {
       try {
-        const result = JSON.stringify({
-          code: `"@component-manifests/${snakeCase(componentKey)}": "*"`,
-        });
-        return formatToolResult(result);
+        return formatToolResult(
+          JSON.stringify({
+            code: `"@component-manifests/${snakeCase(componentKey)}": "*"`,
+            instruction:
+              "The AI agent should update the componentRegistry file after installation.",
+          }),
+        );
       } catch (error) {
         throw new Error(`Failed to generate boilerplate: ${(error as Error).message}`);
       }
@@ -550,7 +558,9 @@ function registerTools(toolsets: string[] = []) {
     const invalidToolsets = toolsets.filter((toolset) => !VALID_TOOLSETS.includes(toolset));
     if (invalidToolsets.length > 0) {
       throw Error(
-        `Invalid toolset: ${invalidToolsets.join(", ")}. Valid categories are: ${VALID_TOOLSETS.join(", ")}`,
+        `Invalid toolset: ${invalidToolsets.join(
+          ", ",
+        )}. Valid categories are: ${VALID_TOOLSETS.join(", ")}`,
       );
     }
   }
@@ -582,7 +592,7 @@ async function main() {
     const args = process.argv.slice(2);
     const workingDirectory = args[0];
     const toolsetsArg = args.slice(1); // Remaining arguments are toolsets
-    
+
     if (!workingDirectory) {
       console.error("Error: WORKING_DIRECTORY argument is required");
       console.error("Usage: prism-mcp <working-directory> [toolsets...]");
@@ -591,7 +601,7 @@ async function main() {
 
     // Initialize the manager with working directory from command line first
     PrismCLIManager.getInstance(workingDirectory, process.env.PRISMATIC_URL);
-    
+
     // Then register tools with specified toolsets (or all if none specified)
     registerTools(toolsetsArg);
     const transport = new StdioServerTransport();

--- a/src/prism-cli-manager.ts
+++ b/src/prism-cli-manager.ts
@@ -1,8 +1,4 @@
-import { exec } from "node:child_process";
-import { promisify } from "node:util";
-import { findPrismPath } from "./helpers.js";
-
-export const execAsync = promisify(exec);
+import { execAsync, findPrismPath } from "./helpers.js";
 
 export const DEFAULT_PRISMATIC_URL = "https://app.prismatic.io/";
 

--- a/src/prism-cli-manager.ts
+++ b/src/prism-cli-manager.ts
@@ -1,13 +1,8 @@
 import { exec } from "node:child_process";
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { existsSync } from "fs";
+import { findPrismPath } from "./helpers.js";
 
 export const execAsync = promisify(exec);
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 export const DEFAULT_PRISMATIC_URL = "https://app.prismatic.io/";
 
@@ -26,7 +21,7 @@ export class PrismCLIManager {
   private constructor(workingDirectory: string, prismaticUrl?: string) {
     this.workingDirectory = workingDirectory;
     this.prismaticUrl = prismaticUrl || DEFAULT_PRISMATIC_URL;
-    this.prismPath = this.findPrismPath();
+    this.prismPath = "";
   }
 
   /**
@@ -47,7 +42,7 @@ export class PrismCLIManager {
     if (!workingDirectory) {
       throw new Error("A working directory must be provided.");
     }
-    
+
     const url = prismaticUrl || process.env.PRISMATIC_URL;
     PrismCLIManager.instance = new PrismCLIManager(workingDirectory, url);
     return PrismCLIManager.instance;
@@ -59,7 +54,8 @@ export class PrismCLIManager {
    */
   private async checkCLIInstallation(): Promise<boolean | string> {
     try {
-      await execAsync(`${this.prismPath} --version`);
+      const path = await this.getPrismPath();
+      await execAsync(`${path} --version`);
       return true;
     } catch {
       return false;
@@ -85,6 +81,8 @@ export class PrismCLIManager {
       );
     }
 
+    const path = await this.getPrismPath();
+
     try {
       const execOptions: any = {
         cwd: customCwd || this.workingDirectory,
@@ -94,8 +92,7 @@ export class PrismCLIManager {
         },
       };
 
-      const { stdout, stderr } = await execAsync(`${this.prismPath} ${command}`, execOptions);
-
+      const { stdout, stderr } = await execAsync(`${path} ${command}`, execOptions);
       return { stdout: stdout.toString(), stderr: stderr.toString() };
     } catch (error) {
       throw new Error(
@@ -169,29 +166,17 @@ export class PrismCLIManager {
    * Finds the path to the Prismatic CLI.
    * @returns {string} The path to the Prismatic CLI
    */
-  private findPrismPath(): string {
-    // Check if custom path is set via environment variable
-    if (process.env.PRISM_PATH && existsSync(process.env.PRISM_PATH)) {
-      return process.env.PRISM_PATH;
+  public async getPrismPath(): Promise<string> {
+    if (this.prismPath) {
+      return this.prismPath;
     }
 
-    // Otherwise use local node_modules installation
-    const localBin = path.join(
-      __dirname,
-      "..",
-      "node_modules",
-      "@prismatic-io",
-      "prism",
-      "lib",
-      "run.js",
-    );
-
-    if (existsSync(localBin)) {
-      return localBin;
+    const foundPath = await findPrismPath();
+    if (foundPath) {
+      this.prismPath = foundPath;
+      return foundPath;
     }
 
-    throw new Error(
-      "Prismatic CLI not found. Please ensure @prismatic-io/prism is installed or set PRISM_PATH environment variable.",
-    );
+    throw new Error("Prismatic CLI not found. Please ensure @prismatic-io/prism is installed.");
   }
 }


### PR DESCRIPTION
A few more fixes after testing post-publish:

* Updated README w/ invocation arguments in the correct order
* Removed PRISM_PATH env var in favor of borrowing [findExecutablePath](https://github.com/prismatic-io/vscode/blob/main/src/extension/findExecutablePath.ts) from VSCode extension
* Added explicit instruction for the AI agent to add component manifests to the registry post-installation