### PR TITLE
Support searching on list tools; provide clearer instructions for component usage; smooth out flow testing process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism-mcp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "MCP server that wraps Prismatic's Prism CLI tool",
   "keywords": ["prismatic"],
   "main": "dist/index.js",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -32,11 +32,7 @@ ${name}: configPage({
 `;
 }
 
-export function generateConfigVar(
-  name: string,
-  dataType: string,
-  description?: string
-): string {
+export function generateConfigVar(name: string, dataType: string, description?: string): string {
   return `
 "${name}": configVar({
   stableKey: "${kebabCase(name)}",
@@ -50,7 +46,7 @@ export function generateConnectionConfigVar(
   name: string,
   componentRef?: { componentKey: string; connectionKey: string },
   directory?: string,
-  forceLegacy?: boolean
+  forceLegacy?: boolean,
 ): { response: string; type: string } {
   const isComponentRef = componentRef?.componentKey;
   let response = "";
@@ -65,7 +61,7 @@ export function generateConnectionConfigVar(
       type = "path";
     } else if (!forceLegacy) {
       throw new Error(
-        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`,
       );
     } else {
       response = `
@@ -105,7 +101,7 @@ export function generateDataSourceConfigVar(
   dataType: string,
   componentRef?: { componentKey: string; dataSourceKey: string },
   directory?: string,
-  forceLegacy?: boolean
+  forceLegacy?: boolean,
 ): { response: string; type: string } {
   const isComponentRef = componentRef?.componentKey;
   let response = "";
@@ -120,7 +116,7 @@ export function generateDataSourceConfigVar(
       type = "path";
     } else if (!forceLegacy) {
       throw new Error(
-        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`,
       );
     } else {
       response = `

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -32,7 +32,11 @@ ${name}: configPage({
 `;
 }
 
-export function generateConfigVar(name: string, dataType: string, description?: string): string {
+export function generateConfigVar(
+  name: string,
+  dataType: string,
+  description?: string
+): string {
   return `
 "${name}": configVar({
   stableKey: "${kebabCase(name)}",
@@ -46,36 +50,40 @@ export function generateConnectionConfigVar(
   name: string,
   componentRef?: { componentKey: string; connectionKey: string },
   directory?: string,
-  forceLegacy?: boolean,
-): string {
+  forceLegacy?: boolean
+): { response: string; type: string } {
   const isComponentRef = componentRef?.componentKey;
+  let response = "";
+  let type = "code";
+
   if (isComponentRef) {
     const connectionPath = `${directory}/src/manifests/${componentRef.componentKey}/connections/`;
     const manifestInSrc = existsSync(connectionPath);
 
     if (manifestInSrc) {
-      return connectionPath;
+      response = connectionPath;
+      type = "path";
     } else if (!forceLegacy) {
       throw new Error(
-        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`,
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
       );
-    }
-
-    return `
-"${name}": connectionConfigVar({
-  stableKey: "${kebabCase(name)}",
-  dataType: "connection",
-  connection: {
-    component: "${componentRef.componentKey}",
-    key: "${componentRef.connectionKey}",
-    values: {
-      // Fill according to type hinting.
+    } else {
+      response = `
+  "${name}": connectionConfigVar({
+    stableKey: "${kebabCase(name)}",
+    dataType: "connection",
+    connection: {
+      component: "${componentRef.componentKey}",
+      key: "${componentRef.connectionKey}",
+      values: {
+        // Fill according to type hinting.
+      },
     },
-  },
-}),
-`;
+  }),
+  `;
+    }
   } else {
-    return `
+    response = `
 "${name}": connectionConfigVar({
   stableKey: "${kebabCase(name)}",
   dataType: "connection",
@@ -85,6 +93,11 @@ export function generateConnectionConfigVar(
 }),
 `;
   }
+
+  return {
+    response,
+    type,
+  };
 }
 
 export function generateDataSourceConfigVar(
@@ -92,22 +105,25 @@ export function generateDataSourceConfigVar(
   dataType: string,
   componentRef?: { componentKey: string; dataSourceKey: string },
   directory?: string,
-  forceLegacy?: boolean,
-): string {
+  forceLegacy?: boolean
+): { response: string; type: string } {
   const isComponentRef = componentRef?.componentKey;
+  let response = "";
+  let type = "code";
+
   if (isComponentRef) {
     const dataSourcePath = `${directory}/src/manifests/${componentRef.componentKey}/dataSources/`;
     const manifestInSrc = existsSync(dataSourcePath);
 
     if (manifestInSrc) {
-      return dataSourcePath;
+      response = dataSourcePath;
+      type = "path";
     } else if (!forceLegacy) {
       throw new Error(
-        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`,
+        `A component manifest was not found for ${componentRef.componentKey}. Attempt prism_install_component_manifest or prism_install_legacy_component_manifest first.`
       );
-    }
-
-    return `
+    } else {
+      response = `
 "${name}": dataSourceConfigVar({
   stableKey: "${kebabCase(name)}",
   dataType: "${dataType}",
@@ -123,8 +139,9 @@ export function generateDataSourceConfigVar(
   },
 }),
 `;
+    }
   } else {
-    return `
+    response = `
 "${name}": dataSourceConfigVar({
   dataSourceType: "${dataType}",
   stableKey: "${kebabCase(name)}",
@@ -134,4 +151,9 @@ export function generateDataSourceConfigVar(
 }),
 `;
   }
+
+  return {
+    response,
+    type,
+  };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,6 +1,5 @@
 import { exec } from "node:child_process";
 import { findExecutablePath } from "./findExecutablePath.js";
-import { PrismCLIManager } from "./prism-cli-manager.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { promisify } from "node:util";
 
@@ -31,43 +30,6 @@ export function formatToolResult(stdout: string, dataKey?: string): CallToolResu
       ],
     };
   }
-}
-
-/**
- * Look up flow URL by ID or name
- */
-export async function lookupFlowUrl(
-  integrationId: string,
-  flowId?: string,
-  flowName?: string,
-): Promise<string> {
-  if (!flowId && !flowName) {
-    throw new Error("Either a flow ID or flow name must be provided");
-  }
-
-  const manager = PrismCLIManager.getInstance();
-  const listCommand = buildCommand(`integrations:flows:list "${integrationId}"`, {
-    extended: true,
-    output: "json",
-  });
-  const { stdout: flowsJson } = await manager.executeCommand(listCommand);
-  const flows = JSON.parse(flowsJson);
-
-  const flow = flows.find(
-    (f: { id: string; name: string; url?: string }) =>
-      (flowId && f.id === flowId) || (flowName && f.name === flowName),
-  );
-
-  if (!flow) {
-    throw new Error(`Flow not found with ${flowId ? `ID: ${flowId}` : `name: ${flowName}`}`);
-  }
-
-  const flowUrl = flow.webhookUrl || flow.url;
-  if (!flowUrl) {
-    throw new Error("Flow does not have a webhook URL");
-  }
-
-  return flowUrl;
 }
 
 /**


### PR DESCRIPTION
This PR includes the following:

* List tools now will attempt to use the "--search" flag if prism supports it. If the user is using an older version of prism, the agent will fall back to listing w/o seach.
* Tools re: component installation and connection usage now provide clearer instructions to the AI agent, pushing it in the direction of using wrapper functions provided by the manifests.
* The `integrations:flows:test` tool has been updated, running into fewer errors re: flow URL lookups and test payload file usage.