### PR TITLE
Reformat release bump output so biome check passes

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -30,6 +30,9 @@ VERSION=$(node -p "require('./package.json').version") node -e "
   server.packages[0].version = process.env.VERSION;
   fs.writeFileSync('server.json', JSON.stringify(server, null, 2) + '\\n');
 "
+# npm version and JSON.stringify re-expand single-element arrays, which the
+# publish-time `biome check` rejects. Reformat so the release commit is clean.
+bun biome format --write package.json server.json
 """
 
 [tasks.release]

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.4.3",
   "mcpName": "io.github.prismatic-io/prism-mcp",
   "description": "MCP server that wraps Prismatic's Prism CLI tool",
-  "keywords": [
-    "prismatic"
-  ],
+  "keywords": ["prismatic"],
   "main": "dist/index.js",
   "type": "module",
   "homepage": "https://prismatic.io",
@@ -20,9 +18,7 @@
     "access": "public",
     "registry": "https://registry.npmjs.org"
   },
-  "files": [
-    "dist/"
-  ],
+  "files": ["dist/"],
   "license": "MIT",
   "bin": {
     "prism-mcp": "dist/index.js"
@@ -47,7 +43,5 @@
     "typescript": "^6.0.3"
   },
   "types": "./dist/index.d.ts",
-  "trustedDependencies": [
-    "@biomejs/biome"
-  ]
+  "trustedDependencies": ["@biomejs/biome"]
 }

--- a/server.json
+++ b/server.json
@@ -39,10 +39,7 @@
             "toolFilter": {
               "description": "Limit tools to a specific domain",
               "isRequired": false,
-              "choices": [
-                "integration",
-                "component"
-              ],
+              "choices": ["integration", "component"],
               "placeholder": "integration"
             }
           }


### PR DESCRIPTION
## Summary
- `npm version` and the `server.json` `JSON.stringify` rewrite in `mise run version-bump` re-expand single-element arrays to multi-line form, which the publish-time `biome check` rejects. The `Release` workflow's `publish` job has been failing here since the release process was added.
- Append `bun biome format --write package.json server.json` at the tail of the `version-bump` task so future release commits are biome-clean.
- Reformat the two files that are currently misformatted on `main` (left over from the failed v1.4.3 release run).

## Context
The v1.4.3 release run on 2026-04-20 pushed a "Release v1.4.3" commit and a `v1.4.3` git tag, but the `publish` job failed validate and never ran `npm publish` or the MCP registry publish. npm's latest is still v1.4.2. After this PR lands, a fresh `mise run release patch` will cleanly cut v1.4.4. (Or the v1.4.3 tag can be deleted and re-dispatched if you'd prefer to reuse the version number — destructive, worth confirming before doing.)

## Test plan
- [x] `mise run validate` passes locally
- [ ] CI `validate` passes on this PR
- [ ] After merge, dispatch a patch release and confirm `publish` job completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)